### PR TITLE
Feature/add install parameter

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -36,7 +36,7 @@ WS_TYPE=""
 WS_REQUIREMENTS_FILE="$SCRIPT_DIR/ws_requirements.txt"
 
 # Parse the agumments, looking for the -W option.
-parseArguments() {
+parse_arguments() {
     while getopts ":W:" opt; do
         case $opt in
             W) WS_VALUE=$OPTARG

--- a/install/install.sh
+++ b/install/install.sh
@@ -197,22 +197,23 @@ install_config() {
 #
 update_config() {
   if [[ -n "$WS_TYPE" ]]; then
-    local DEVICE_JSON="$CONFIG_DIR/device.json"
+      local DEVICE_JSON="$CONFIG_DIR/device.json"
 
-    if grep -q '"display_type":' "$DEVICE_JSON"; then
-      # display_type is defined - update it with supplied value
-      sed -i "s/\"display_type\": \".*\"/\"display_type\": \"$WS_TYPE\"/" "$DEVICE_JSON"
-      echo "Updated ws_value to: $WS_TYPE" 
-    else
-      # is not there so append it
-      # Ensure proper comma placement before adding ws_value
-      sed -i '$s/}/,/' "$DEVICE_JSON"  # Replace last } with a comma
-      echo "  \"display_type\": \"$WS_TYPE\"" >> "$DEVICE_JSON"
-      echo "}" >> "$DEVICE_JSON"  # Add the trailing }
-      echo "Added ws_value: $WS_TYPE"
-    fi
+      if grep -q '"display_type":' "$DEVICE_JSON"; then
+          # Update existing display_type value
+          sed -i "s/\"display_type\": \".*\"/\"display_type\": \"$WS_TYPE\"/" "$DEVICE_JSON"
+          echo "Updated display_type to: $WS_TYPE" 
+      else
+          # Append display_type safely, ensuring proper comma placement
+          if grep -q '}$' "$DEVICE_JSON"; then
+              sed -i '$s/}/,/' "$DEVICE_JSON"  # Replace last } with a comma
+          fi
+          echo "  \"display_type\": \"$WS_TYPE\"" >> "$DEVICE_JSON"
+          echo "}" >> "$DEVICE_JSON"  # Add trailing }
+          echo "Added display_type: $WS_TYPE"
+      fi
   else
-    echo "Config not updated as WS type flag not set"
+      echo "Config not updated as WS_TYPE flag is not set"
   fi
 }
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -78,16 +78,22 @@ enable_interfaces(){
     # WS parameter is set for Waveshare support so ensure that both CS lines
     # are enabled in the config.txt file.  This is different to INKY which
     # only needs one line set.n
-    echo_success "Enabling both CS lines for SPI interface in config.txt"
-    sed -i '/^dtparam=spi=on/a dtoverlay=spi0-2cs' /boot/firmware/config.txt
+    echo "Enabling both CS lines for SPI interface in config.txt"
+    if ! grep -E -q '^[[:space:]]*dtoverlay=spi0-2cs' /boot/firmware/config.txt; then
+        sed -i '/^dtparam=spi=on/a dtoverlay=spi0-2cs' /boot/firmware/config.txt
+    else
+        echo "dtoverlay for spi0-2cs already specified"
+    fi
   else
     # TODO - check if really need the dtparam set for INKY as this seems to be 
     # only for the older screens (as per INKY docs)
     echo "Enabling single CS line for SPI interface in config.txt"
-    sed -i '/^dtparam=spi=on/a dtoverlay=spi0-0cs' /boot/firmware/config.txt
-  fi
-
-  
+    if ! grep -E -q '^[[:space:]]*dtoverlay=spi0-0cs' /boot/firmware/config.txt; then
+        sed -i '/^dtparam=spi=on/a dtoverlay=spi0-0cs' /boot/firmware/config.txt
+    else
+        echo "dtoverlay for spi0-0cs already specified"
+    fi
+  fi 
 }
 
 show_loader() {

--- a/install/install.sh
+++ b/install/install.sh
@@ -33,19 +33,19 @@ PIP_REQUIREMENTS_FILE="$SCRIPT_DIR/requirements.txt"
 # empty means no WS support required, otherwise we expect the type of display
 # as per the WS naming convention.
 WS_TYPE=""
-WS_REQUIREMENTS_FILE="$SCRIPT_DIR/ws_requirements.txt"
+WS_REQUIREMENTS_FILE="$SCRIPT_DIR/ws-requirements.txt"
 
 # Parse the agumments, looking for the -W option.
 parse_arguments() {
     while getopts ":W:" opt; do
         case $opt in
-            W) WS_VALUE=$OPTARG
-                echo "WS flag is set with value: $WS_VALUE"
+            W) WS_TYPE=$OPTARG
+                echo "Optional parameter WS is set for Waveshare support.  Screen type is: $WS_TYPE"
                 ;;
             \?) echo "Invalid option: -$OPTARG." >&2
                 exit 1
                 ;;
-            :) echo "Option -$OPTARG requires an argument." >&2
+            :) echo "Option -$OPTARG requires an the model type of the Waveshare screen." >&2
                exit 1
                ;;
         esac
@@ -75,11 +75,10 @@ enable_interfaces(){
 
   # Is a Waveshare device specified as an install parameter?
   if [[ -n "$WS_TYPE" ]]; then
-    # WS parameter is set for Waveshare support so endure that both CS lines
+    # WS parameter is set for Waveshare support so ensure that both CS lines
     # are enabled in the config.txt file.  This is different to INKY which
-    # only needs one line set.
-    #
-    echo "Enabling both CS lines for SPI interface in config.txt"
+    # only needs one line set.n
+    echo_success "Enabling both CS lines for SPI interface in config.txt"
     sed -i '/^dtparam=spi=on/a dtoverlay=spi0-2cs' /boot/firmware/config.txt
   else
     # TODO - check if really need the dtparam set for INKY as this seems to be 

--- a/install/install.sh
+++ b/install/install.sh
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+# =============================================================================
+# Script Name: install.sh
+# Description: This script automates the installatin of InkyPI and creation of
+#              the InkyPI service.
+#
+# Usage: ./install.sh [-W <waveshare_device>]
+#        -W <waveshare_device> (optional) Install for a Waveshare device, 
+#                               specifying the device model type, e.g. epd7in3e.
+#
+#                               If not specified then the Pimoroni Inky display
+#                               is assumed.
+# =============================================================================
+
 # Formatting stuff
 bold=$(tput bold)
 normal=$(tput sgr0)

--- a/install/ws-requirements.txt
+++ b/install/ws-requirements.txt
@@ -1,0 +1,3 @@
+gpiozero==2.0.1
+lgpio==0.2.2.0
+RPi.GPIO==0.7.1


### PR DESCRIPTION
Added support for an optional installation parameter -W <device> to support Waveshare devices.  When defined, installation will:

- Install additional libraries required for the Waveshare in the python envionment. 
- Mark up the configuration file _device.json_ with a new optional element `display_type` that if defined holds the model number for the Waveshare device.
- Ensures that the correct entry is in _config.txt_ as the Waveshare device requires both CS lines defined in `dtoverlay`.