### PR TITLE
Refactor and remove duplicate code.

### DIFF
--- a/src/display/abstract_display.py
+++ b/src/display/abstract_display.py
@@ -32,7 +32,8 @@ class AbstractDisplay:
 
     def display_image(self, image, image_settings=[]):
         """
-        Abstract method to display an image on the screen.
+        Abstract method to display an image on the screen.  Implementations of this
+        method should handle the device specific operations.
 
         Args:
             image (PIL.Image): The image to be displayed.

--- a/src/display/display_manager.py
+++ b/src/display/display_manager.py
@@ -2,6 +2,7 @@ import fnmatch
 import json
 import logging
 
+from utils.image_utils import resize_image, change_orientation
 from display.inky_display import InkyDisplay
 from display.waveshare_display import WaveshareDisplay
 
@@ -35,6 +36,8 @@ class DisplayManager:
             # otherwise we will have to enshring the manufacturer in the 
             # display_type and then have a display_model parameter.  Will leave
             # that for future use if the need arises.
+            #
+            # see https://github.com/waveshareteam/e-Paper
             self.display = WaveshareDisplay(device_config)
         else:
             raise ValueError(f"Unsupported display type: {display_type}")
@@ -55,4 +58,13 @@ class DisplayManager:
         if not hasattr(self, "display"):
             raise ValueError("No valid display instance initialized.")
         
+        # Save the image
+        logger.info(f"Saving image to {self.device_config.current_image_file}")
+        image.save(self.device_config.current_image_file)
+
+        # Resize and adjust orientation
+        image = change_orientation(image, self.device_config.get_config("orientation"))
+        image = resize_image(image, self.device_config.get_resolution(), image_settings)
+
+        # Pass to the concrete instance to render to the device.
         self.display.display_image(image, image_settings)

--- a/src/display/inky_display.py
+++ b/src/display/inky_display.py
@@ -1,7 +1,7 @@
 import logging
 from inky.auto import auto
 from display.abstract_display import AbstractDisplay
-from utils.image_utils import resize_image, change_orientation
+
 
 logger = logging.getLogger(__name__)
 
@@ -42,8 +42,8 @@ class InkyDisplay(AbstractDisplay):
         """
         Displays the provided image on the Inky display.
 
-        The image is processed by adjusting orientation and resizing before 
-        being sent to the display.
+        The image has been processed by adjusting orientation and resizing 
+        before being sent to the display.
 
         Args:
             image (PIL.Image): The image to be displayed.
@@ -56,14 +56,6 @@ class InkyDisplay(AbstractDisplay):
         logger.info("Displaying image to Inky display.")
         if not image:
             raise ValueError(f"No image provided.")
-
-        # Save the image
-        logger.info(f"Saving image to {self.device_config.current_image_file}")
-        image.save(self.device_config.current_image_file)
-
-        # Resize and adjust orientation
-        image = change_orientation(image, self.device_config.get_config("orientation"))
-        image = resize_image(image, self.device_config.get_resolution(), image_settings)
 
         # Display the image on the Inky display
         self.inky_display.set_image(image)

--- a/src/display/waveshare_display.py
+++ b/src/display/waveshare_display.py
@@ -2,7 +2,6 @@ import importlib
 import logging
 
 from display.abstract_display import AbstractDisplay
-from utils.image_utils import resize_image, change_orientation
 from plugins.plugin_registry import get_plugin_instance
 
 logger = logging.getLogger(__name__)
@@ -66,7 +65,7 @@ class WaveshareDisplay(AbstractDisplay):
         """
         Displays an image on the Waveshare display.
 
-        The image is processed by adjusting orientation, resizing, and converting it
+        The image has been processed by adjusting orientation, resizing, and converting it
         into the buffer format required for e-paper rendering.
 
         Args:
@@ -81,20 +80,13 @@ class WaveshareDisplay(AbstractDisplay):
         if not image:
             raise ValueError(f"No image provided.")
 
-        # Save the image
-        logger.info(f"Saving image to {self.device_config.current_image_file}")
-        image.save(self.device_config.current_image_file)
-
-        # Resize and adjust orientation
-        image = change_orientation(image, self.device_config.get_config("orientation"))
-        image = resize_image(image, self.device_config.get_resolution(), image_settings)
-
+        # Assume device was in sleep mode.
         self.epd_display.init()
 
         # Clear residual pixels before updating the image.
         self.epd_display.Clear()
 
-        # Display the image on the Inky display
+        # Display the image on the WS display.
         self.epd_display.display(self.epd_display.getbuffer(image))
 
         # Put device into low power mode (EPD displays maintain image when powered off)


### PR DESCRIPTION
Minor refactoring pulling the image resize code in to super class.  Now the concrete implementations should only worry about pushing the image to the device.